### PR TITLE
scripts/run-tests: ModuleNotFoundError: No module named 'compilers'

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ def importModule(lang: str, kind: Literal['compile', 'interp', 'ast', 'parse']):
         return None
     match kind:
         case "compile":
-            modName = f'compilers.lang_{lang}.{lang}_compiler'
+            modName = f'lang_{lang}.{lang}_compiler'
         case "parse":
             modName = f'parsers.lang_{lang}.{lang}_parser'
         case "interp":


### PR DESCRIPTION
I get the following error if I follow the assignment 1 instructions:
1. create `src/lang_var/var_compiler.py`
2. add `[...] def compileModule(m: mod, cfg: CompilerConfig) -> WasmModule [...]`
3. enable `lang_var` tests
4. run `scripts/run-tests -k 'test_compiler[var'`


```bash
Traceback (most recent call last):
  File "/cc/./src/main.py", line 173, in <module>
    main()
  File "/cc/./src/main.py", line 142, in main
    compilerMod = importModule(lang, 'compile')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cc/./src/main.py", line 94, in importModule
    m = importlib.import_module(modName)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'compilers'
```

This also occurs for manually executing the compiler through:
- `scripts/run compile ./test_files/lang_var/add.py`
- `scripts/run --lang=var compile test_files/lang_var/add.py`
- `python3.12 ./src/main.py compile ./test_files/lang_var/add.py`

## Workaround
This PR removes the `compilers` top-level module with results in the expected error (since the prototype function only returns `None`)
```
Traceback (most recent call last):
  File "/cc/./src/main.py", line 173, in <module>
    main()
  File "/cc/./src/main.py", line 146, in main
    genericCompiler.compileMain(compileArgs, compileFun, ast)
  File "/cc/src/common/genericCompiler.py", line 52, in compileMain
    wasmMod = compileToWat(compileFun, astMod, cfg, args.input, outputWat)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cc/src/common/genericCompiler.py", line 23, in compileToWat
    code = sexp.renderSExp(wasmMod.render())
                           ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'render'
```

`parser` follows similar semantics, but has not been tested.


Or might be just a miss application from my side ¯\\_(ツ)_\/¯ 